### PR TITLE
Fix responseFactory not exist before 10.1

### DIFF
--- a/Classes/Middleware/MiddlewareAbstract.php
+++ b/Classes/Middleware/MiddlewareAbstract.php
@@ -10,6 +10,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 abstract class MiddlewareAbstract implements MiddlewareInterface {
   /**
@@ -58,7 +61,13 @@ abstract class MiddlewareAbstract implements MiddlewareInterface {
   }
 
   public function createResponse(string $string, bool $jsonOutput = true): ResponseInterface {
-    $response = $this->responseFactory->createResponse();
+    $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
+    if (version_compare($typo3Version->getVersion(), '10.1.0') >= 0) {
+      $response = $this->responseFactory->createResponse();
+    } else {
+      $response = new Response();
+    }
+
     if ($jsonOutput) {
       $response = $response->withHeader('Content-Type', 'application/json; charset=utf-8');
     }


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.1/Feature-89018-ProvideImplementationForPSR-17HTTPMessageFactories.html
