### PR TITLE
Fix undefined constant

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,6 +1,6 @@
 <?php
 
-defined('TYPO3') || exit();
+defined('TYPO3') || defined('TYPO3_MODE') || exit('Access denied.');
 
 (static function () {
 })();


### PR DESCRIPTION
Constant 'TYPO3' not exist before version 11.


https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Deprecation-92947-DeprecateTYPO3_MODEAndTYPO3_REQUESTTYPEConstants.html