### PR TITLE
Restore default createResponse contentType to JSON

### DIFF
--- a/Classes/Middleware/MiddlewareAbstract.php
+++ b/Classes/Middleware/MiddlewareAbstract.php
@@ -74,6 +74,7 @@ abstract class MiddlewareAbstract implements MiddlewareInterface {
     }
 
     switch ($contentType) {
+      case ContentTypeDefinition::DEFAULT:
       case ContentTypeDefinition::JSON:
         $response = $response->withHeader('Content-Type', 'application/json; charset=utf-8');
         break;

--- a/Classes/Middleware/MiddlewareAbstract.php
+++ b/Classes/Middleware/MiddlewareAbstract.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 
 namespace JAKOTA\Typo3ToolBox\Middleware;
 
+use InvalidArgumentException;
 use JAKOTA\Typo3ToolBox\Definition\ContentTypeDefinition;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -64,7 +66,10 @@ abstract class MiddlewareAbstract implements MiddlewareInterface {
       }
     }
   }
-
+  /**
+   *
+   * @param string $contentType Defaults to JSON content type if omitted.
+   */
   public function createResponse(string $string, string $contentType = ContentTypeDefinition::DEFAULT): ResponseInterface {
     $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);
     if (version_compare($typo3Version->getVersion(), '10.1.0') >= 0) {


### PR DESCRIPTION
This should break less code if the parameter was omitted.