### PR TITLE
PDO => Connection

### DIFF
--- a/Classes/Routing/Aspect/TransSitePersistedAliasMapper.php
+++ b/Classes/Routing/Aspect/TransSitePersistedAliasMapper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace JAKOTA\Typo3ToolBox\Routing\Aspect;
 
-use Doctrine\DBAL\Connection;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Routing\Aspect\PersistedAliasMapper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -21,7 +21,7 @@ class TransSitePersistedAliasMapper extends PersistedAliasMapper {
     $constraints = [
       $queryBuilder->expr()->eq(
         $this->routeFieldName,
-        $queryBuilder->createNamedParameter($value, \PDO::PARAM_STR)
+        $queryBuilder->createNamedParameter($value, Connection::PARAM_STR)
       ),
     ];
 

--- a/Classes/ViewHelpers/FindImageMetadataFromDBViewHelper.php
+++ b/Classes/ViewHelpers/FindImageMetadataFromDBViewHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 
 namespace JAKOTA\Typo3ToolBox\ViewHelpers;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -31,8 +32,8 @@ class FindImageMetadataFromDBViewHelper extends AbstractViewHelper {
     $queryBuilder = $queryBuilder
       ->select('*')
       ->from('sys_file_metadata')
-      ->where($queryBuilder->expr()->eq('sys_file_metadata.file', $queryBuilder->createNamedParameter($this->arguments['uid'], \PDO::PARAM_STR)))
-      ->andWhere($queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($this->arguments['language'], \PDO::PARAM_STR)))
+      ->where($queryBuilder->expr()->eq('sys_file_metadata.file', $queryBuilder->createNamedParameter($this->arguments['uid'], Connection::PARAM_STR)))
+      ->andWhere($queryBuilder->expr()->eq('sys_language_uid', $queryBuilder->createNamedParameter($this->arguments['language'], Connection::PARAM_STR)))
     ;
 
     $typo3Version = GeneralUtility::makeInstance(Typo3Version::class);


### PR DESCRIPTION
In typo3 v13 the 2. parameter type  was changed from inti to string. This change uses the internal type to match the on for the underlying DB.