### PR TITLE
Add buildUri function to Middleware

### DIFF
--- a/Classes/Middleware/MiddlewareActionAbstract.php
+++ b/Classes/Middleware/MiddlewareActionAbstract.php
@@ -151,7 +151,7 @@ abstract class MiddlewareActionAbstract extends ApiAbstract {
         strtolower("tx_{$extensionName}_{$pluginName}") => [
           'action' => $actionName,
           'controller' => $controllerName,
-          $actionArguments,
+          ...$actionArguments,
         ],
       ];
     }

--- a/Classes/Middleware/MiddlewareActionAbstract.php
+++ b/Classes/Middleware/MiddlewareActionAbstract.php
@@ -130,28 +130,33 @@ abstract class MiddlewareActionAbstract extends ApiAbstract {
   /**
    * Function to build urls without using $this->uriBuilder.
    *
-   * @param null|string $extensionName   Extension name without underscores. Eg. 'myextension'
-   * @param null|string $pluginName      Plugin name with underscores. Eg. 'news_show' or 'records_list'
-   * @param null|string $actionName      Action name (the 'show' of 'news_show')
-   * @param null|string $controllerName  Name of the controller. Eg. 'News' or 'Record'
-   * @param null|array  $actionArguments Additional arguments needed for the Action. Eg. [newsId => 123, ...]
+   * @param null|array<string, mixed>   $additionalGetParams  Additional GET parameters.
+   * @param null|string                 $extensionName        Extension name without underscores. Eg. 'myextension'
+   * @param null|string                 $pluginName           Plugin name with underscores. Eg. 'news_show' or 'records_list'
+   * @param null|string                 $actionName           Action name (the 'show' of 'news_show')
+   * @param null|string                 $controllerName       Name of the controller. Eg. 'News' or 'Record'
+   * @param null|array<string, mixed>   $actionArguments      Additional arguments needed for the Action. Eg. [newsId => 123, ...]
    */
-  protected function buildUri(int $pageId, ?string $extensionName = null, ?string $pluginName = null, ?string $actionName = null, ?string $controllerName = null, ?array $actionArguments = null): ?UriInterface {
-    if (null === $this->site->getRouter()) {
+  protected function buildUri(int $pageId, ?array $additionalGetParams = [], ?string $extensionName = null, ?string $pluginName = null, ?string $actionName = null, ?string $controllerName = null, array $actionArguments = []): ?UriInterface {
+    if (null === ($this->site?->getRouter() ?? null)) {
       return null;
     }
+
+    $arguments = [
+      ...$additionalGetParams
+    ];
 
     if (null !== $extensionName && null !== $pluginName && null !== $actionName && null !== $controllerName) {
       $arguments = [
         strtolower("tx_{$extensionName}_{$pluginName}") => [
           'action' => $actionName,
           'controller' => $controllerName,
-          ...$actionArguments,
+          $actionArguments,
         ],
       ];
     }
 
-    return $this->site->getRouter()->generateUri($this->site->getAttribute('shipDetailPageUid'), $arguments ?? []);
+    return $this->site->getRouter()->generateUri($this->site->getAttribute('shipDetailPageUid'), $arguments);
   }
 
   protected function getAbsPath(?FileReference $file): string {

--- a/Classes/Middleware/MiddlewareActionAbstract.php
+++ b/Classes/Middleware/MiddlewareActionAbstract.php
@@ -156,7 +156,7 @@ abstract class MiddlewareActionAbstract extends ApiAbstract {
       ];
     }
 
-    return $this->site->getRouter()->generateUri($this->site->getAttribute('shipDetailPageUid'), $arguments);
+    return $this->site->getRouter()->generateUri($pageId, $arguments);
   }
 
   protected function getAbsPath(?FileReference $file): string {

--- a/Classes/Middleware/MiddlewareActionAbstract.php
+++ b/Classes/Middleware/MiddlewareActionAbstract.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 namespace JAKOTA\Typo3ToolBox\Middleware;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Context\UserAspect;
@@ -124,6 +125,33 @@ abstract class MiddlewareActionAbstract extends ApiAbstract {
     }
 
     $this->uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
+  }
+
+  /**
+   * Function to build urls without using $this->uriBuilder.
+   *
+   * @param null|string $extensionName   Extension name without underscores. Eg. 'myextension'
+   * @param null|string $pluginName      Plugin name with underscores. Eg. 'news_show' or 'records_list'
+   * @param null|string $actionName      Action name (the 'show' of 'news_show')
+   * @param null|string $controllerName  Name of the controller. Eg. 'News' or 'Record'
+   * @param null|array  $actionArguments Additional arguments needed for the Action. Eg. [newsId => 123, ...]
+   */
+  protected function buildUri(int $pageId, ?string $extensionName = null, ?string $pluginName = null, ?string $actionName = null, ?string $controllerName = null, ?array $actionArguments = null): ?UriInterface {
+    if (null === $this->site->getRouter()) {
+      return null;
+    }
+
+    if (null !== $extensionName && null !== $pluginName && null !== $actionName && null !== $controllerName) {
+      $arguments = [
+        strtolower("tx_{$extensionName}_{$pluginName}") => [
+          'action' => $actionName,
+          'controller' => $controllerName,
+          ...$actionArguments,
+        ],
+      ];
+    }
+
+    return $this->site->getRouter()->generateUri($this->site->getAttribute('shipDetailPageUid'), $arguments);
   }
 
   protected function getAbsPath(?FileReference $file): string {

--- a/Classes/Middleware/MiddlewareActionAbstract.php
+++ b/Classes/Middleware/MiddlewareActionAbstract.php
@@ -130,20 +130,20 @@ abstract class MiddlewareActionAbstract extends ApiAbstract {
   /**
    * Function to build urls without using $this->uriBuilder.
    *
-   * @param null|array<string, mixed>   $additionalGetParams  Additional GET parameters.
-   * @param null|string                 $extensionName        Extension name without underscores. Eg. 'myextension'
-   * @param null|string                 $pluginName           Plugin name with underscores. Eg. 'news_show' or 'records_list'
-   * @param null|string                 $actionName           Action name (the 'show' of 'news_show')
-   * @param null|string                 $controllerName       Name of the controller. Eg. 'News' or 'Record'
-   * @param null|array<string, mixed>   $actionArguments      Additional arguments needed for the Action. Eg. [newsId => 123, ...]
+   * @param array<string, mixed>  $additionalGetParams additional GET parameters
+   * @param null|string           $extensionName       Extension name without underscores. Eg. 'myextension'
+   * @param null|string           $pluginName          Plugin name with underscores. Eg. 'news_show' or 'records_list'
+   * @param null|string           $actionName          Action name (the 'show' of 'news_show')
+   * @param null|string           $controllerName      Name of the controller. Eg. 'News' or 'Record'
+   * @param array<string, mixed>  $actionArguments     Additional arguments needed for the Action. Eg. [newsId => 123, ...]
    */
-  protected function buildUri(int $pageId, ?array $additionalGetParams = [], ?string $extensionName = null, ?string $pluginName = null, ?string $actionName = null, ?string $controllerName = null, array $actionArguments = []): ?UriInterface {
+  protected function buildUri(int $pageId, array $additionalGetParams = [], ?string $extensionName = null, ?string $pluginName = null, ?string $actionName = null, ?string $controllerName = null, array $actionArguments = []): ?UriInterface {
     if (null === ($this->site?->getRouter() ?? null)) {
       return null;
     }
 
     $arguments = [
-      ...$additionalGetParams
+      ...$additionalGetParams,
     ];
 
     if (null !== $extensionName && null !== $pluginName && null !== $actionName && null !== $controllerName) {

--- a/Classes/Middleware/MiddlewareActionAbstract.php
+++ b/Classes/Middleware/MiddlewareActionAbstract.php
@@ -151,7 +151,7 @@ abstract class MiddlewareActionAbstract extends ApiAbstract {
       ];
     }
 
-    return $this->site->getRouter()->generateUri($this->site->getAttribute('shipDetailPageUid'), $arguments);
+    return $this->site->getRouter()->generateUri($this->site->getAttribute('shipDetailPageUid'), $arguments ?? []);
   }
 
   protected function getAbsPath(?FileReference $file): string {


### PR DESCRIPTION
Starting from Typo3 12 `$this->uribuilder` can no longer be used in the middleware context because it needs extbase configs which are not set at this point.

This MR adds an alternative function to create URIs without the extbase dependencies.